### PR TITLE
Change http scheme to https on some services

### DIFF
--- a/src/net/debian/debiandroid/apiLayer/DFTP.java
+++ b/src/net/debian/debiandroid/apiLayer/DFTP.java
@@ -12,9 +12,9 @@ public class DFTP extends HTTPCaller {
 		super(context);
 	}
 
-	private static final String NEW_PACKAGES_URL = "http://ftp-master.debian.org/new.822";
-	private static final String REMOVALS_URL = "http://ftp-master.debian.org/removals.822";
-	private static final String DEFERRED_URL = "http://ftp-master.debian.org/deferred/status";
+	private static final String NEW_PACKAGES_URL = "https://ftp-master.debian.org/new.822";
+	private static final String REMOVALS_URL = "https://ftp-master.debian.org/removals.822";
+	private static final String DEFERRED_URL = "https://ftp-master.debian.org/deferred/status";
 	
 	public String[] getRawNewPackages() {
 		return doQueryRequest(NEW_PACKAGES_URL).split("\n\n");

--- a/src/net/debian/debiandroid/apiLayer/PTS.java
+++ b/src/net/debian/debiandroid/apiLayer/PTS.java
@@ -23,7 +23,7 @@ public class PTS extends PTSSoapCaller implements Subscribable {
 	public static final String PTSSUBSCRIPTIONS = "PTSSubscriptions";
 	
 	private static final String PTSPCKGNAMESEARCHURL = "http://sources.debian.net/api/search/";
-	private static final String PTSMADISONSEARCHURL = "http://qa.debian.org/madison.php?table=all&package=";
+	private static final String PTSMADISONSEARCHURL = "https://qa.debian.org/madison.php?table=all&package=";
 	
 	public PTS(Context context) {
 		super(context);

--- a/src/net/debian/debiandroid/apiLayer/UDD.java
+++ b/src/net/debian/debiandroid/apiLayer/UDD.java
@@ -10,7 +10,7 @@ public class UDD extends HTTPCaller {
 		super(context);
 	}
 		
-	private static final String UDD_CGI_URL = "http://udd.debian.org/cgi-bin/";
+	private static final String UDD_CGI_URL = "https://udds.debian.org/cgi-bin/";
 	
 	public ArrayList<ArrayList<String>> getLastUploads() {
 		String[] response = doQueryRequest(UDD_CGI_URL + "last-uploads.cgi?out=csv").split("\n");

--- a/src/net/debian/debiandroid/apiLayer/soaptools/BTSSoapCaller.java
+++ b/src/net/debian/debiandroid/apiLayer/soaptools/BTSSoapCaller.java
@@ -13,7 +13,7 @@ public class BTSSoapCaller extends SoapCaller{
     public BTSSoapCaller(Context context) {
     	super(context);
     	NAMESPACE = "Debbugs/SOAP";
-    	URL = "http://bugs.debian.org/cgi-bin/soap.cgi";
+    	URL = "https://bugs.debian.org/cgi-bin/soap.cgi";
     }
     
     /** Key values for 'key' parameter in getBugs method*/

--- a/src/net/debian/debiandroid/apiLayer/soaptools/PTSSoapCaller.java
+++ b/src/net/debian/debiandroid/apiLayer/soaptools/PTSSoapCaller.java
@@ -8,7 +8,7 @@ public class PTSSoapCaller extends SoapCaller{
 
     public PTSSoapCaller(Context context) {
     	super(context);
-    	URL = "http://packages.qa.debian.org/cgi-bin/soap-alpha.cgi";
+    	URL = "https://packages.qa.debian.org/cgi-bin/soap-alpha.cgi";
     }
     
     public String getSOAPAPIVersion() {

--- a/src/net/debian/debiandroid/content/LinksFragment.java
+++ b/src/net/debian/debiandroid/content/LinksFragment.java
@@ -35,10 +35,10 @@ public class LinksFragment extends ItemFragment {
 	private final static HashMap<String, String> links = new HashMap<String, String>(){
 		private static final long serialVersionUID = 5237952374216701176L;
 	{
-	     put("Debian.org", "http://debian.org");
+	     put("Debian.org", "https://www.debian.org");
 	     put("Planet Debian - social", "http://planet.debian.org/");
-	     put("Debian News - rss", "http://www.debian.org/News/news");
-	     put("Debian Security - rss", "http://www.debian.org/security/dsa");
+	     put("Debian News - rss", "https://www.debian.org/News/news");
+	     put("Debian Security - rss", "https://www.debian.org/security/dsa");
 	     put("Debian Twitter - social", "https://twitter.com/debian");
 	     put("Debian Google+ - social","https://plus.google.com/111711190057359692089/posts");
 	     put("Debian Identi.ca - social","https://identi.ca/debian");


### PR DESCRIPTION
Since some Debian have https enabled services and the code don't seem to follow
HTTP 301 redirects, directly use https urls when available.

I don't have tested these changes by rebuilding the application but just noted the failure on last version 1.732 when using an http proxy on search_packages, rcbugs, etc...
