### PR TITLE
Add intent filters for https URLs

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -60,14 +60,26 @@
                     android:host="bugs.debian.org"
                     android:scheme="http" />
                 <data
+                    android:host="bugs.debian.org"
+                    android:scheme="https" />
+                <data
                     android:host="packages.qa.debian.org"
                     android:scheme="http" />
+                <data
+                    android:host="packages.qa.debian.org"
+                    android:scheme="https" />
                 <data
                     android:host="www.bugs.debian.org"
                     android:scheme="http" />
                 <data
+                    android:host="www.bugs.debian.org"
+                    android:scheme="https" />
+                <data
                     android:host="www.packages.qa.debian.org"
                     android:scheme="http" />
+                <data
+                    android:host="www.packages.qa.debian.org"
+                    android:scheme="https" />
             </intent-filter>
         </activity>
         <activity


### PR DESCRIPTION
Most Debian services are preferring https URLs now.  Adding intent filters for the https schema restores DebianDroid as an application that can handle those URLs.
